### PR TITLE
Add missing staking events and fix election events

### DIFF
--- a/types/election_compute.go
+++ b/types/election_compute.go
@@ -66,6 +66,21 @@ func NewElectionCompute(b byte) ElectionCompute {
 	return ElectionCompute(b)
 }
 
+type ElectionScore struct {
+	// The minimal winner, in terms of total backing stake.
+	//
+	// This parameter should be maximized.
+	MinimalStake U128
+	// The sum of the total backing of all winners.
+	//
+	// This parameter should maximized
+	SumStake U128
+	// The sum squared of the total backing of all winners, aka. the variance.
+	//
+	// Ths parameter should be minimized.
+	SumStakeSquared U128
+}
+
 const (
 	// OnChain means that the result was forcefully computed on chain at the end of the session.
 	OnChain ElectionCompute = 0

--- a/types/event_record.go
+++ b/types/event_record.go
@@ -334,6 +334,7 @@ type EventRecords struct {
 	Staking_Slashed                    []EventStakingSlashed                    `test-gen-blockchain:"polkadot"`
 	Staking_StakersElected             []EventStakingStakersElected             `test-gen-blockchain:"polkadot"`
 	Staking_StakingElectionFailed      []EventStakingStakingElectionFailed      `test-gen-blockchain:"polkadot"`
+	Staking_ValidatorPrefsSet          []EventStakingValidatorPrefsSet          `test-gen-blockchain:"polkadot"`
 	Staking_Unbonded                   []EventStakingUnbonded                   `test-gen-blockchain:"polkadot"`
 	Staking_Withdrawn                  []EventStakingWithdrawn                  `test-gen-blockchain:"polkadot"`
 
@@ -563,6 +564,11 @@ func (e EventRecordsRaw) DecodeEventRecords(m *Metadata, t interface{}) error { 
 		log.Debug(fmt.Sprintf("decoded event #%v", i))
 	}
 	return nil
+}
+
+type ValidatorPrefs struct {
+	Commission U128
+	Blocked    bool
 }
 
 // Phase is an enum describing the current phase of the event (applying the extrinsic or finalized)

--- a/types/events.go
+++ b/types/events.go
@@ -565,6 +565,14 @@ type EventStakingUnbonded struct {
 	Topics []Hash
 }
 
+// EventStakingUnbonded is emitted when an account has unbonded this amount
+type EventStakingValidatorPrefsSet struct {
+	Phase  Phase
+	Stash  AccountID
+	Prefs  ValidatorPrefs
+	Topics []Hash
+}
+
 // EventStakingWithdrawn is emitted when an account has called `withdraw_unbonded` and removed unbonding chunks
 // worth `Balance` from the unlocking queue.
 type EventStakingWithdrawn struct {

--- a/types/events.go
+++ b/types/events.go
@@ -1289,7 +1289,7 @@ type EventElectionProviderMultiPhaseSolutionStored struct {
 // with `Some` of the given computation, or else if the election failed, `None`.
 type EventElectionProviderMultiPhaseElectionFinalized struct {
 	Phase           Phase
-	ElectionCompute OptionElectionCompute
+	ElectionCompute ElectionCompute
 	Topics          []Hash
 }
 


### PR DESCRIPTION
Steps to test:
- [x] `go build`
- [x] `gofmt`
- [x] `make test-dockerized`
```
go-substrate-rpc-client  [add-events] [!] via 🐹 v1.20.8 ☃️ shell took 2m13s
➜ make test-dockerized
[+] Building 0.0s (0/0)
[+] Running 1/0
 ✔ Container substrate  Running                                                                                                                                                                                                                                                                                                                                        0.0s
[+] Building 0.8s (9/9) FINISHED
 => [gsrpc-test internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                        0.0s
 => => transferring dockerfile: 32B                                                                                                                                                                                                                                                                                                                                    0.0s
 => [gsrpc-test internal] load .dockerignore                                                                                                                                                                                                                                                                                                                           0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                        0.0s
 => [gsrpc-test internal] load metadata for docker.io/library/golang:1.18                                                                                                                                                                                                                                                                                              0.6s
 => [gsrpc-test 1/5] FROM docker.io/library/golang:1.18@sha256:50c889275d26f816b5314fc99f55425fa76b18fcaf16af255f5d57f09e1f48da                                                                                                                                                                                                                                        0.0s
 => CACHED [gsrpc-test 2/5] RUN apt-get -y update && apt-get -y upgrade && apt-get -y install wget && apt-get install ca-certificates -y                                                                                                                                                                                                                               0.0s
 => CACHED [gsrpc-test 3/5] RUN go version                                                                                                                                                                                                                                                                                                                             0.0s
 => CACHED [gsrpc-test 4/5] RUN mkdir -p /go-substrate-rpc-client                                                                                                                                                                                                                                                                                                      0.0s
 => CACHED [gsrpc-test 5/5] WORKDIR /go-substrate-rpc-client                                                                                                                                                                                                                                                                                                           0.0s
 => [gsrpc-test] exporting to image                                                                                                                                                                                                                                                                                                                                    0.0s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                0.0s
 => => writing image sha256:98bda996f71f8ab4156c4ee42b1e20013cdcaaf69705e66a781ec3f3fff9bf36                                                                                                                                                                                                                                                                           0.0s
 => => naming to docker.io/library/gsrpc-test                                                                                                                                                                                                                                                                                                                          0.0s
[+] Building 0.0s (0/0)
[+] Running 1/0
 ✔ Container go-substrate-rpc-client-gsrpc-test-1  Created                                                                                                                                                                                                                                                                                                             0.0s
Attaching to go-substrate-rpc-client-gsrpc-test-1
go-substrate-rpc-client-gsrpc-test-1  | error obtaining VCS status: exit status 128
go-substrate-rpc-client-gsrpc-test-1  |         Use -buildvcs=false to disable VCS stamping.
go-substrate-rpc-client-gsrpc-test-1  | 2023/12/06 09:31:50 Connecting to ws://substrate:9944...
go-substrate-rpc-client-gsrpc-test-1  | 2023/12/06 09:31:50 Connecting to ws://substrate:9944...
go-substrate-rpc-client-gsrpc-test-1  | PASS
go-substrate-rpc-client-gsrpc-test-1  | coverage: 71.4% of statements
go-substrate-rpc-client-gsrpc-test-1  | ok      github.com/Cerebellum-Network/go-substrate-rpc-client/v4        0.916s
go-substrate-rpc-client-gsrpc-test-1 exited with code 0
Aborting on container exit...
[+] Stopping 1/0
 ✔ Container go-substrate-rpc-client-gsrpc-test-1  Stopped  
```